### PR TITLE
Macos grips

### DIFF
--- a/otty/src/components/primitive/resize_grips.rs
+++ b/otty/src/components/primitive/resize_grips.rs
@@ -5,11 +5,6 @@ use iced::{Element, Length, Theme, mouse};
 const RESIZE_EDGE_THICKNESS: f32 = 6.0;
 const RESIZE_CORNER_THICKNESS: f32 = 12.0;
 
-/// Return whether custom drag-resize grips are supported on this platform.
-pub(crate) const fn is_supported() -> bool {
-    !cfg!(target_os = "macos")
-}
-
 /// Events emitted by the window resize grips.
 #[derive(Debug, Clone)]
 pub(crate) enum ResizeGripEvent {

--- a/otty/src/components/primitive/resize_grips.rs
+++ b/otty/src/components/primitive/resize_grips.rs
@@ -5,6 +5,11 @@ use iced::{Element, Length, Theme, mouse};
 const RESIZE_EDGE_THICKNESS: f32 = 6.0;
 const RESIZE_CORNER_THICKNESS: f32 = 12.0;
 
+/// Return whether custom drag-resize grips are supported on this platform.
+pub(crate) const fn is_supported() -> bool {
+    !cfg!(target_os = "macos")
+}
+
 /// Events emitted by the window resize grips.
 #[derive(Debug, Clone)]
 pub(crate) enum ResizeGripEvent {

--- a/otty/src/events/mod.rs
+++ b/otty/src/events/mod.rs
@@ -72,11 +72,15 @@ pub(crate) fn handle(app: &mut App, event: AppEvent) -> Task<AppEvent> {
             )
         },
         AppEvent::ResizeWindow(dir) => {
-            if crate::components::primitive::resize_grips::is_supported() {
+            #[cfg(target_os = "macos")]
+            {
+                Task::none()
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            {
                 window::latest()
                     .and_then(move |id| window::drag_resize(id, dir))
-            } else {
-                Task::none()
             }
         },
         AppEvent::Window(_) => Task::none(),

--- a/otty/src/events/mod.rs
+++ b/otty/src/events/mod.rs
@@ -72,7 +72,12 @@ pub(crate) fn handle(app: &mut App, event: AppEvent) -> Task<AppEvent> {
             )
         },
         AppEvent::ResizeWindow(dir) => {
-            window::latest().and_then(move |id| window::drag_resize(id, dir))
+            if crate::components::primitive::resize_grips::is_supported() {
+                window::latest()
+                    .and_then(move |id| window::drag_resize(id, dir))
+            } else {
+                Task::none()
+            }
         },
         AppEvent::Window(_) => Task::none(),
     }

--- a/otty/src/view.rs
+++ b/otty/src/view.rs
@@ -112,8 +112,7 @@ pub(super) fn view(app: &App) -> Element<'_, AppEvent, Theme, iced::Renderer> {
         .into();
 
     #[cfg(not(target_os = "macos"))]
-    let resize_grips_layer = if 
-        app.widgets.sidebar.has_add_menu_open()
+    let resize_grips_layer = if app.widgets.sidebar.has_add_menu_open()
         || app.widgets.quick_launch.context_menu().is_some()
         || app.widgets.terminal_workspace.has_any_context_menu()
     {

--- a/otty/src/view.rs
+++ b/otty/src/view.rs
@@ -105,7 +105,8 @@ pub(super) fn view(app: &App) -> Element<'_, AppEvent, Theme, iced::Renderer> {
         .width(Length::Fill)
         .height(Length::Fill);
 
-    let resize_grips_layer = if app.widgets.sidebar.has_add_menu_open()
+    let resize_grips_layer = if !resize_grips::is_supported()
+        || app.widgets.sidebar.has_add_menu_open()
         || app.widgets.quick_launch.context_menu().is_some()
         || app.widgets.terminal_workspace.has_any_context_menu()
     {

--- a/otty/src/view.rs
+++ b/otty/src/view.rs
@@ -105,8 +105,15 @@ pub(super) fn view(app: &App) -> Element<'_, AppEvent, Theme, iced::Renderer> {
         .width(Length::Fill)
         .height(Length::Fill);
 
-    let resize_grips_layer = if !resize_grips::is_supported()
-        || app.widgets.sidebar.has_add_menu_open()
+    #[cfg(target_os = "macos")]
+    let resize_grips_layer = container(Space::new())
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+    #[cfg(not(target_os = "macos"))]
+    let resize_grips_layer = if 
+        app.widgets.sidebar.has_add_menu_open()
         || app.widgets.quick_launch.context_menu().is_some()
         || app.widgets.terminal_workspace.has_any_context_menu()
     {


### PR DESCRIPTION
## Type of change

- [ ] New Feature
- [ ] Experimental Feature
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Backward Incompatible Change
- [ ] Build/Testing/Packaging Improvement
- [ ] Documentation (changelog entry is not required)
- [ ] Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- [x] Bug Fix (user-visible misbehavior in an official stable release)
- [ ] CI Fix or Improvement (changelog entry is not required)
- [ ] Not for changelog (changelog entry is not required)

## User readable description
Fix custom resize grips on macos because winit is not supported custom resize events on macos 