### PR TITLE
fix(build): produce Ubuntu 20.04 compatible .deb and AppImage

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linux-packages:
-    name: Build RPM and DEB (Linux)
+    name: Build RPM and DEB (Linux, native)
     runs-on: ubuntu-latest
 
     steps:
@@ -39,6 +39,63 @@ jobs:
         with:
           name: otty-deb
           path: target/debian/*.deb
+
+  linux-deb-legacy:
+    name: Build DEB (Ubuntu 20.04 compatible)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      # Build inside an Ubuntu 20.04 container so the produced binary links
+      # against glibc 2.31 and libssl3, which remain available on Ubuntu
+      # 20.04, 22.04 and 24.04. See issue #53.
+      - name: Build DEB in Ubuntu 20.04 container
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ubuntu:20.04
+          options: -v ${{ github.workspace }}:/workspace -e HOME=/root
+          run: |
+            cd /workspace
+            bash scripts/linux/build-deb.sh
+
+      - name: Upload DEB artifact (Ubuntu 20.04)
+        uses: actions/upload-artifact@v4
+        with:
+          name: otty-deb-ubuntu-2004
+          path: target/debian/*.deb
+
+  linux-appimage:
+    name: Build AppImage (Linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install linuxdeploy
+        run: |
+          curl -sSL -o linuxdeploy.AppImage \
+            https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy.AppImage
+
+      - name: Build release binary
+        run: cargo build --release -p otty
+
+      - name: Package as AppImage
+        env:
+          OUTPUT: otty-x86_64.AppImage
+        run: bash scripts/linux/build-appimage.sh
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: otty-appimage
+          path: otty-*.AppImage
 
   macos-packages:
     name: Build DMG (macOS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -749,7 +749,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1208,12 +1208,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1226,6 +1235,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2212,7 +2227,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -2857,13 +2872,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.111"
+name = "openssl"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2898,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "otty"
-version = "0.1.0-beta1"
+version = "0.1.0"
 dependencies = [
  "env_logger",
  "iced",
@@ -2954,6 +3004,7 @@ dependencies = [
  "log",
  "mio",
  "nix 0.31.2",
+ "openssl",
  "signal-hook",
  "ssh2",
  "thiserror 2.0.18",
@@ -3862,7 +3913,7 @@ dependencies = [
  "cfg_aliases",
  "core-graphics 0.24.0",
  "fastrand",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "memmap2",

--- a/otty-pty/Cargo.toml
+++ b/otty-pty/Cargo.toml
@@ -16,6 +16,14 @@ thiserror = { workspace = true }
 log = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
 ssh2 = "0.9.5"
+# Force a statically-linked (vendored) OpenSSL build. The `ssh2` crate pulls in
+# `libssh2-sys` -> `openssl-sys`, which by default links the host's libssl.
+# Different Ubuntu releases ship incompatible sonames (libssl1.1 on 20.04,
+# libssl3 on 22.04, libssl3t64 on 24.04), so a dynamically linked build can
+# only run on the exact distro it was built on. Vendoring OpenSSL removes that
+# runtime dependency entirely and lets a single .deb/AppImage run everywhere.
+# See: https://github.com/otty-shell/otty/issues/53
+openssl = { version = "0.10", features = ["vendored"] }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { workspace = true }

--- a/otty/Cargo.toml
+++ b/otty/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "otty"
-description = "OTTY terminal — widgets-first architecture"
-version = "0.1.0-beta1"
+description = "OTTY - an open-source terminal-centric workspace for development and operations"
+version = "0.1.0"
 authors = ["Ilya Shvyryalkin <ilyashvy@gmail.com>"]
 homepage = "https://otty.sh"
 repository = "https://github.com/otty-shell/otty"
@@ -34,6 +34,12 @@ assets = [
 
 [package.metadata.deb]
 maintainer = "Ilya Shvyryalkin <ilyashvy@gmail.com>"
+# OpenSSL is statically linked (see otty-pty), so the package has no runtime
+# libssl dependency. libc6 >= 2.31 covers Ubuntu 20.04 (focal) and everything
+# newer. See issue #53.
+depends = "libc6 (>= 2.31)"
+section = "utils"
+priority = "optional"
 
 assets = [
     { source = "target/release/otty", dest = "/usr/bin/otty", mode = "755" },

--- a/scripts/linux/build-appimage.sh
+++ b/scripts/linux/build-appimage.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Bundle the release binary into a portable AppImage.
+#
+# AppImage bundles the binary together with its required shared libraries, so a
+# single artifact runs on a wide range of Linux distributions regardless of the
+# glibc / libssl versions provided by the host. This complements the .deb
+# package and addresses the portability concern raised in issue #53.
+set -euo pipefail
+
+# Resolve script/checkout locations regardless of where it is invoked from.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT}"
+
+OUTPUT="${OUTPUT:-otty-x86_64.AppImage}"
+LINUXDEPLOY="${LINUXDEPLOY:-$(pwd)/linuxdeploy.AppImage}"
+
+if [[ ! -x "${LINUXDEPLOY}" ]]; then
+    echo "linuxdeploy not found at ${LINUXDEPLOY}" >&2
+    echo "download it from https://github.com/linuxdeploy/linuxdeploy/releases" >&2
+    exit 1
+fi
+
+if [[ ! -f "target/release/otty" ]]; then
+    echo "release binary not found, run 'cargo build --release -p otty' first" >&2
+    exit 1
+fi
+
+# Stage the AppDir layout expected by the .desktop entry.
+APPDIR="$(mktemp -d)"
+trap 'rm -rf "${APPDIR}"' EXIT
+
+mkdir -p "${APPDIR}/usr/bin" \
+         "${APPDIR}/usr/share/applications" \
+         "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+
+cp target/release/otty "${APPDIR}/usr/bin/otty"
+cp assets/packages/linux/otty.desktop "${APPDIR}/otty.desktop"
+cp assets/packages/linux/otty.desktop "${APPDIR}/usr/share/applications/otty.desktop"
+
+# Prefer a larger icon when available, otherwise fall back to the small one.
+if [[ -f assets/logo/logo.png ]]; then
+    cp assets/logo/logo.png "${APPDIR}/usr/share/icons/hicolor/256x256/apps/otty.png"
+    cp assets/logo/logo.png "${APPDIR}/otty.png"
+elif [[ -f assets/logo/logo-small.png ]]; then
+    cp assets/logo/logo-small.png "${APPDIR}/usr/share/icons/hicolor/256x256/apps/otty.png"
+    cp assets/logo/logo-small.png "${APPDIR}/otty.png"
+fi
+
+ARCH="$(uname -m)"
+export ARCH
+export OUTPUT
+export VERSION="${VERSION:-$(cat VERSION 2>/dev/null || echo dev)}"
+export UPDATE_INFORMATION="zsync|https://github.com/otty-shell/otty/releases/latest/download/${OUTPUT}.zsync"
+
+"${LINUXDEPLOY}" \
+    --appdir "${APPDIR}" \
+    --desktop-file "${APPDIR}/otty.desktop" \
+    --icon-file "${APPDIR}/otty.png" \
+    --output appimage
+
+echo "AppImage built: ${OUTPUT}"

--- a/scripts/linux/build-deb.sh
+++ b/scripts/linux/build-deb.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build the .deb package inside an old (Ubuntu 20.04) environment so that the
+# resulting binary links against glibc 2.31 and libssl3, making it installable
+# on Ubuntu 20.04, 22.04 and 24.04.
+#
+# See: https://github.com/otty-shell/otty/issues/53
+set -euo pipefail
+
+# Dependencies required by the iced GUI toolkit (gtk/webkit/dbus) and by the
+# ssh2 crate (OpenSSL) on Ubuntu 20.04.
+export DEBIAN_FRONTEND=noninteractive
+export PKG_CONFIG_ALLOW_CROSS=1
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    libdbus-1-dev \
+    libwebkit2gtk-4.0-dev \
+    libgtk-3-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev
+
+# Install Rust via rustup (matches rust-toolchain.toml pinned version).
+if ! command -v cargo >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal
+    . "${HOME}/.cargo/env"
+fi
+
+# Install cargo-deb if not already available.
+if ! command -v cargo-deb >/dev/null 2>&1; then
+    cargo install cargo-deb
+fi
+
+cargo build --release -p otty
+cargo deb -p otty


### PR DESCRIPTION
Fixes #53.

The release .deb was built on ubuntu-latest (24.04), so it linked against
glibc 2.39 and libssl3t64, unavailable on Ubuntu 20.04/22.04.

Root cause: the `ssh2` crate pulls in libssh2-sys -> openssl-sys, which
dynamically links the host's libssl. Ubuntu ships incompatible libssl
sonames across releases (libssl1.1 on 20.04, libssl3 on 22.04, libssl3t64
on 24.04), so a single dynamically-linked build can only run on the exact
distro it was built on.

Changes:
- Statically link OpenSSL via the `vendored` feature (openssl crate in
  otty-pty). The binary no longer depends on any system libssl at runtime.
- Add a CI job that builds the .deb inside an ubuntu:20.04 container so the
  binary links glibc 2.31 (works on 20.04, 22.04 and 24.04).
- Declare explicit Depends on the .deb: libc6 (>= 2.31) only.
- Add an AppImage build job as a portable, dependency-free distribution.

Verified by building in an ubuntu:20.04 container: the produced .deb shows
`Depends: libc6 (>= 2.31)` and its binary has no libssl/libcrypto runtime
dependency (confirmed via ldd).