### PR TITLE
fix: render Thai combining vowels and tone marks correctly

### DIFF
--- a/otty-libterm/src/lib.rs
+++ b/otty-libterm/src/lib.rs
@@ -25,6 +25,9 @@ mod runtime;
 mod terminal;
 
 pub use error::{Error, Result};
+pub use otty_escape as escape;
+pub use otty_pty as pty;
+pub use otty_surface as surface;
 pub use runtime::{Driver, Runtime, RuntimeHooks, RuntimeRequestProxy};
 pub use terminal::builder::{
     DefaultParser, DefaultSurface, RuntimeTerminal, Terminal, TerminalBuilder,
@@ -38,7 +41,6 @@ pub use terminal::size::TerminalSize;
 pub use terminal::{
     SnapshotArc, TerminalEngine, TerminalEvent, TerminalRequest,
 };
-pub use {otty_escape as escape, otty_pty as pty, otty_surface as surface};
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/otty-libterm/src/lib.rs
+++ b/otty-libterm/src/lib.rs
@@ -25,9 +25,6 @@ mod runtime;
 mod terminal;
 
 pub use error::{Error, Result};
-pub use otty_escape as escape;
-pub use otty_pty as pty;
-pub use otty_surface as surface;
 pub use runtime::{Driver, Runtime, RuntimeHooks, RuntimeRequestProxy};
 pub use terminal::builder::{
     DefaultParser, DefaultSurface, RuntimeTerminal, Terminal, TerminalBuilder,
@@ -41,6 +38,7 @@ pub use terminal::size::TerminalSize;
 pub use terminal::{
     SnapshotArc, TerminalEngine, TerminalEvent, TerminalRequest,
 };
+pub use {otty_escape as escape, otty_pty as pty, otty_surface as surface};
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/otty-surface/src/surface.rs
+++ b/otty-surface/src/surface.rs
@@ -856,8 +856,34 @@ impl Dimensions for Surface {
     }
 }
 
+/// Decompose a Thai/Lao "AM" vowel into its zero-width mark and spacing
+/// vowel.
+///
+/// `THAI SARA AM` (U+0E33) and `LAO AM` (U+0EB3) have a display width of 1,
+/// so without decomposition they are shaped as standalone glyphs. Splitting
+/// them lets the nikhahit/niggahita ring render over the preceding
+/// consonant, matching how the character is actually drawn.
+fn decompose_am(ch: char) -> Option<(char, char)> {
+    match ch {
+        // THAI SARA AM -> THAI CHARACTER NIKHAHIT + THAI CHARACTER SARA AA.
+        '\u{0E33}' => Some(('\u{0E4D}', '\u{0E32}')),
+        // LAO AM -> LAO NIGGAHITA + LAO VOWEL SIGN AA.
+        '\u{0EB3}' => Some(('\u{0ECD}', '\u{0EB2}')),
+        _ => None,
+    }
+}
+
 impl SurfaceActor for Surface {
     fn print(&mut self, ch: char) {
+        // Split Thai/Lao "AM" vowels so their nikhahit/niggahita mark is
+        // placed over the preceding consonant cell, instead of standing
+        // alone in its own cell.
+        if let Some((mark, base)) = decompose_am(ch) {
+            self.print(mark);
+            self.print(base);
+            return;
+        }
+
         // Number of cells the char will occupy.
         let width = match ch.width() {
             Some(width) => width,
@@ -2523,6 +2549,51 @@ mod tests {
         surface.print('a');
 
         assert_eq!(surface.grid()[cursor].c, '▒');
+    }
+
+    #[test]
+    fn thai_sara_am_decomposes_over_preceding_consonant() {
+        let size = SurfaceSize::new(7, 17);
+        let mut surface = Surface::new(SurfaceConfig::default(), &size);
+        surface.print('\u{0E01}'); // THAI CHARACTER KO KAI (ก).
+        surface.print('\u{0E33}'); // THAI CHARACTER SARA AM (ำ).
+
+        let first = surface.grid()[Point::new(Line(0), Column(0))].clone();
+        let second = surface.grid()[Point::new(Line(0), Column(1))].clone();
+
+        assert_eq!(first.c, '\u{0E01}');
+        assert_eq!(first.zerowidth(), Some(&['\u{0E4D}'][..]));
+        assert_eq!(second.c, '\u{0E32}');
+    }
+
+    #[test]
+    fn lao_am_decomposes_over_preceding_consonant() {
+        let size = SurfaceSize::new(7, 17);
+        let mut surface = Surface::new(SurfaceConfig::default(), &size);
+        surface.print('\u{0E81}'); // LAO LETTER KO.
+        surface.print('\u{0EB3}'); // LAO AM.
+
+        let first = surface.grid()[Point::new(Line(0), Column(0))].clone();
+        let second = surface.grid()[Point::new(Line(0), Column(1))].clone();
+
+        assert_eq!(first.c, '\u{0E81}');
+        assert_eq!(first.zerowidth(), Some(&['\u{0ECD}'][..]));
+        assert_eq!(second.c, '\u{0EB2}');
+    }
+
+    #[test]
+    fn thai_sara_am_at_column_zero_does_not_panic() {
+        let size = SurfaceSize::new(7, 17);
+        let mut surface = Surface::new(SurfaceConfig::default(), &size);
+
+        // No preceding consonant: the nikhahit mark has no earlier cell to
+        // attach to, so it lands on the same cell as the spacing vowel that
+        // follows it and is overwritten. This mirrors how a bare zero-width
+        // combining mark at column 0 already behaves in `print`.
+        surface.print('\u{0E33}');
+
+        let cell = surface.grid()[Point::new(Line(0), Column(0))].clone();
+        assert_eq!(cell.c, '\u{0E32}');
     }
 
     #[test]

--- a/otty-ui/terminal/src/view.rs
+++ b/otty-ui/terminal/src/view.rs
@@ -687,7 +687,12 @@ impl Widget<Event, Theme, iced::Renderer> for TerminalView<'_> {
                 }
 
                 // Draw text
-                if indexed.cell.c != ' ' && indexed.cell.c != '\t' {
+                let zerowidth = indexed.cell.zerowidth();
+                let has_zerowidth =
+                    zerowidth.is_some_and(|marks| !marks.is_empty());
+                if (indexed.cell.c != ' ' && indexed.cell.c != '\t')
+                    || has_zerowidth
+                {
                     if view.cursor.point == indexed.point
                         && !view.mode.contains(SurfaceMode::ALT_SCREEN)
                     {
@@ -701,8 +706,14 @@ impl Widget<Event, Theme, iced::Renderer> for TerminalView<'_> {
                     if flags.contains(Flags::ITALIC) {
                         font.style = FontStyle::Italic;
                     }
+                    // Append zerowidth combining marks (e.g. Thai vowels/tone
+                    // marks) so cosmic-text shapes them over the base glyph.
+                    let mut content = indexed.cell.c.to_string();
+                    if let Some(marks) = zerowidth {
+                        content.extend(marks);
+                    }
                     let text = Text {
-                        content: indexed.cell.c.to_string(),
+                        content,
                         position: Point::new(cell_center_x, cell_center_y),
                         font,
                         size: iced_core::Pixels(font_size),

--- a/otty/src/events/mod.rs
+++ b/otty/src/events/mod.rs
@@ -1,5 +1,7 @@
+use iced::Task;
+#[cfg(not(target_os = "macos"))]
+use iced::window;
 use iced::window::Direction;
-use iced::{Task, window};
 
 use crate::app::App;
 use crate::layout::screen_size_from_window;
@@ -71,17 +73,11 @@ pub(crate) fn handle(app: &mut App, event: AppEvent) -> Task<AppEvent> {
                 ),
             )
         },
+        #[cfg(target_os = "macos")]
+        AppEvent::ResizeWindow(_) => Task::none(),
+        #[cfg(not(target_os = "macos"))]
         AppEvent::ResizeWindow(dir) => {
-            #[cfg(target_os = "macos")]
-            {
-                Task::none()
-            }
-
-            #[cfg(not(target_os = "macos"))]
-            {
-                window::latest()
-                    .and_then(move |id| window::drag_resize(id, dir))
-            }
+            window::latest().and_then(move |id| window::drag_resize(id, dir))
         },
         AppEvent::Window(_) => Task::none(),
     }

--- a/otty/src/view.rs
+++ b/otty/src/view.rs
@@ -3,9 +3,9 @@ use iced::widget::{Space, column, container, mouse_area, row, text};
 use iced::{Element, Length, Size, Theme, alignment};
 
 use super::{App, AppEvent};
-use crate::components::primitive::{
-    menu_item, resize_grips, sidebar_workspace_panel,
-};
+#[cfg(not(target_os = "macos"))]
+use crate::components::primitive::resize_grips;
+use crate::components::primitive::{menu_item, sidebar_workspace_panel};
 use crate::geometry::{anchor_position, menu_height_for_items};
 use crate::layout::BUTTON_SIZE_COMPACT;
 use crate::style::menu_panel_style;

--- a/otty/src/widgets/settings/reducer.rs
+++ b/otty/src/widgets/settings/reducer.rs
@@ -122,7 +122,10 @@ mod tests {
     #[test]
     fn given_save_completed_when_reduced_then_marks_state_saved() {
         let mut state = default_state();
-        state.set_shell(String::from("/bin/zsh"));
+        // Derive a value guaranteed to differ from whatever $SHELL the test
+        // runner defaults to, so this test isn't environment-dependent.
+        let new_shell = format!("{}-test", state.draft().terminal_shell());
+        state.set_shell(new_shell);
         assert!(state.is_dirty());
         let normalized = state.normalized_draft();
 

--- a/otty/src/widgets/settings/state.rs
+++ b/otty/src/widgets/settings/state.rs
@@ -222,10 +222,13 @@ mod tests {
     #[test]
     fn given_default_state_when_set_shell_then_marks_dirty() {
         let mut state = SettingsState::default();
+        // Derive a value guaranteed to differ from whatever $SHELL the test
+        // runner defaults to, so this test isn't environment-dependent.
+        let new_shell = format!("{}-test", state.draft.terminal_shell());
 
-        state.set_shell(String::from("/bin/zsh"));
+        state.set_shell(new_shell.clone());
 
-        assert_eq!(state.draft.terminal_shell(), "/bin/zsh");
+        assert_eq!(state.draft.terminal_shell(), new_shell);
         assert!(state.dirty);
     }
 


### PR DESCRIPTION
## Type of change

- [ ] New Feature
- [ ] Experimental Feature
- [ ] Improvement
- [ ] Performance Improvement
- [ ] Backward Incompatible Change
- [ ] Build/Testing/Packaging Improvement
- [ ] Documentation (changelog entry is not required)
- [ ] Critical Bug Fix (crash, data loss, RBAC) or LOGICAL_ERROR
- [x] Bug Fix (user-visible misbehavior in an official stable release)
- [ ] CI Fix or Improvement (changelog entry is not required)
- [ ] Not for changelog (changelog entry is not required)

## User readable description

Thai text rendered with combining vowels and tone marks in the wrong position (or dropped entirely). Words such as `ที่นี่`, `น้ำ`, or `กำลัง` lost their upper/lower vowels and tone marks.

Two root causes, fixed here:

1. **Renderer dropped zero-width combining marks** (`otty-ui-term`). The grid correctly stores combining characters per cell via `Cell::zerowidth()`, but the draw loop built each cell's `Text` from the base character alone, so the marks never reached the shaper. The draw loop now appends the stored marks to the shaped content, letting cosmic-text position the full grapheme cluster over the base glyph. Cells whose base is a space but which carry combining marks are now drawn as well.

2. **THAI SARA AM (U+0E33) shaped standalone** (`otty-surface`). SARA AM has display width 1, so it landed in its own cell and its nikhahit ring rendered detached from the preceding consonant. `print()` now decomposes it into NIKHAHIT (zero-width, attached to the previous cell) + SARA AA (spacing), matching how the character is actually drawn. The Lao analog (U+0EB3 → U+0ECD + U+0EB2) is handled the same way. Note: copied text containing ำ now yields the decomposed pair, which is canonically equivalent under NFC normalization.

Also included:

- Settings shell dirty-tracking tests no longer depend on the machine's `$SHELL` (they hardcoded `/bin/zsh` and failed on zsh machines).
- macOS clippy warnings (imports/bindings used only by the non-macOS resize path) and pending rustfmt drift in `otty-libterm` re-exports.

### Before / after

Before: upper/lower vowels and tone marks missing or floating (e.g. `ที่นี่มีน้ำ` rendered as bare consonants).
After: all marks shape correctly over their base consonants — verified visually with a test matrix covering upper vowels (กิ กี กึ กื กั), sara am (กำ น้ำ ทำไม), lower vowels (กุ กู ปู่), and tone marks (ก่ ก้ ก๊ ก๋).

### Verification

- `cargo test --workspace --all-features`: 445 passed, 0 failed (includes 3 new decomposition unit tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo +nightly fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
