### PR TITLE
fix(pty): use OpenSSL crypto backend on Windows for curve25519 KEX

### DIFF
--- a/otty-pty/Cargo.toml
+++ b/otty-pty/Cargo.toml
@@ -16,8 +16,9 @@ thiserror = { workspace = true }
 log = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
 # `openssl-on-win32`: make the Windows build use the (vendored) OpenSSL
-# crypto backend instead of WinCNG. WinCNG offers only finite-field DH key
-# exchange, which modern servers (OpenSSH >= 10) no longer accept.
+# crypto backend instead of WinCNG. libssh2's WinCNG backend only
+# advertises finite-field DH key exchange (it does not implement ECDH or
+# curve25519), which modern servers (OpenSSH >= 10) no longer accept.
 ssh2 = { version = "0.9.5", features = ["openssl-on-win32"] }
 # Force a statically-linked (vendored) OpenSSL build. The `ssh2` crate pulls in
 # `libssh2-sys` -> `openssl-sys`, which by default links the host's libssl.

--- a/otty-pty/Cargo.toml
+++ b/otty-pty/Cargo.toml
@@ -15,7 +15,10 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 mio = { workspace = true, features = ["os-ext", "net"] }
-ssh2 = "0.9.5"
+# `openssl-on-win32`: make the Windows build use the (vendored) OpenSSL
+# crypto backend instead of WinCNG. WinCNG offers only finite-field DH key
+# exchange, which modern servers (OpenSSH >= 10) no longer accept.
+ssh2 = { version = "0.9.5", features = ["openssl-on-win32"] }
 # Force a statically-linked (vendored) OpenSSL build. The `ssh2` crate pulls in
 # `libssh2-sys` -> `openssl-sys`, which by default links the host's libssl.
 # Different Ubuntu releases ship incompatible sonames (libssl1.1 on 20.04,


### PR DESCRIPTION
## Problem

SSH sessions from a Windows build of otty fail during the handshake against modern SSH servers (OpenSSH >= 10) with:

```
ssh error: [Session(-5)] Unable to exchange encryption keys
```

## Root cause

The server-side log (OpenSSH 10.0, Debian 13) shows what a Windows build of libssh2 actually offers:

```
Unable to negotiate with <ip>: no matching key exchange method found.
Their offer: diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,
diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1,
diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1 [preauth]
```

The offer is missing `curve25519-sha256` and `ecdh-sha2-nistp*`. Reason: in `libssh2-sys`'s `build.rs`, Windows targets default to the **WinCNG** crypto backend unless the `openssl-on-win32` feature is enabled. WinCNG only supports finite-field DH key exchange. OpenSSH 10 servers by default offer only `mlkem768x25519`, `sntrup761x25519`, `curve25519` and `ecdh-sha2-nistp*` — zero intersection with WinCNG's offer, so the KEX negotiation fails.

This affects any Rust project using `ssh2` with default features on Windows connecting to OpenSSH >= 10 servers, not just otty.

## Fix

Enable `ssh2`'s `openssl-on-win32` feature. The crate already forces a vendored OpenSSL build (see the comment above the `openssl` dependency), so libssh2 now compiles against the same vendored OpenSSL on Windows and offers `curve25519-sha256` / `ecdh-sha2-nistp*` again. On unix this feature is a no-op (the OpenSSL branch is already taken there).

## Verification

- `nm` on the Windows `libssh2.a` after the change: contains `_libssh2_curve25519_new` / `_libssh2_curve25519_gen_k` and 70+ `EVP_*` symbol references (previously none — WinCNG build)
- End-to-end on a Windows host: otty now connects to an OpenSSH 10.0 server and reaches the shell (previously `Session(-5)` at handshake)
- `cargo clippy -p otty-pty --all-targets --all-features -- -D warnings`, `cargo test -p otty-pty --all-features`, `cargo deny check` all green