### PR TITLE
fix(settings): block edits while a save is in flight

### DIFF
--- a/app/src/widgets/settings/mod.rs
+++ b/app/src/widgets/settings/mod.rs
@@ -54,6 +54,7 @@ impl SettingsWidget {
             selected_path: self.state.selected_path(),
             hovered_path: self.state.hovered_path(),
             is_dirty: self.state.is_dirty(),
+            is_saving: self.state.is_saving(),
         }
     }
 

--- a/app/src/widgets/settings/model.rs
+++ b/app/src/widgets/settings/model.rs
@@ -13,4 +13,5 @@ pub(crate) struct SettingsViewModel<'a> {
     pub(super) selected_path: &'a Vec<String>,
     pub(super) hovered_path: Option<&'a Vec<String>>,
     pub(super) is_dirty: bool,
+    pub(super) is_saving: bool,
 }

--- a/app/src/widgets/settings/reducer.rs
+++ b/app/src/widgets/settings/reducer.rs
@@ -10,6 +10,10 @@ pub(crate) fn reduce(
     state: &mut SettingsState,
     event: SettingsIntent,
 ) -> Task<SettingsEvent> {
+    if state.is_saving() && changes_draft(&event) {
+        return Task::none();
+    }
+
     match event {
         SettingsIntent::Reload => request_reload_settings(),
         SettingsIntent::ReloadLoaded(load) => {
@@ -30,6 +34,7 @@ pub(crate) fn reduce(
             )))
         },
         SettingsIntent::SaveFailed(message) => {
+            state.mark_save_failed();
             log::warn!("settings save failed: {message}");
             Task::none()
         },
@@ -68,6 +73,19 @@ pub(crate) fn reduce(
     }
 }
 
+/// Return whether the intent edits the draft the user is about to save.
+fn changes_draft(event: &SettingsIntent) -> bool {
+    matches!(
+        event,
+        SettingsIntent::Reset
+            | SettingsIntent::ShellChanged(_)
+            | SettingsIntent::EditorChanged(_)
+            | SettingsIntent::EqualizePanesToggled(_)
+            | SettingsIntent::PaletteChanged { .. }
+            | SettingsIntent::ApplyPreset(_)
+    )
+}
+
 fn request_reload_settings() -> Task<SettingsEvent> {
     Task::perform(async { load_settings() }, |result| match result {
         Ok(load) => SettingsEvent::Effect(SettingsEffect::ReloadLoaded(load)),
@@ -77,8 +95,11 @@ fn request_reload_settings() -> Task<SettingsEvent> {
     })
 }
 
-fn request_save_settings(state: &SettingsState) -> Task<SettingsEvent> {
-    let normalized = state.normalized_draft();
+fn request_save_settings(state: &mut SettingsState) -> Task<SettingsEvent> {
+    let Some(normalized) = state.begin_save() else {
+        return Task::none();
+    };
+
     Task::perform(
         async move {
             match save_settings(&normalized) {
@@ -128,19 +149,64 @@ mod tests {
         let mut state = default_state();
         state.set_shell(format!("{}-changed", state.draft().terminal_shell()));
         assert!(state.is_dirty());
-        let normalized = state.normalized_draft();
+        let normalized = state.begin_save().expect("save should start");
 
         let _task =
             reduce(&mut state, SettingsIntent::SaveCompleted(normalized));
 
         assert!(!state.is_dirty());
+        assert!(!state.is_saving());
         assert_eq!(state.baseline(), state.draft());
+    }
+
+    #[test]
+    fn given_save_in_flight_when_edit_intent_reduced_then_draft_unchanged() {
+        let mut state = default_state();
+        state.set_shell(format!("{}-changed", state.draft().terminal_shell()));
+        let saved = state.begin_save().expect("save should start");
+
+        let _task = reduce(
+            &mut state,
+            SettingsIntent::EditorChanged(String::from("nvim")),
+        );
+
+        assert_ne!(state.draft().terminal_editor(), "nvim");
+
+        let _task =
+            reduce(&mut state, SettingsIntent::SaveCompleted(saved.clone()));
+
+        assert_eq!(state.baseline(), &saved);
+        assert_eq!(state.draft(), &saved);
+        assert!(!state.is_dirty());
+    }
+
+    #[test]
+    fn given_save_in_flight_when_reset_intent_reduced_then_draft_unchanged() {
+        let mut state = default_state();
+        state.set_shell(format!("{}-changed", state.draft().terminal_shell()));
+        let saved = state.begin_save().expect("save should start");
+
+        let _task = reduce(&mut state, SettingsIntent::Reset);
+
+        assert_eq!(state.draft(), &saved);
+    }
+
+    #[test]
+    fn given_save_in_flight_when_save_intent_reduced_then_no_second_save() {
+        let mut state = default_state();
+        state.set_shell(format!("{}-changed", state.draft().terminal_shell()));
+        let _saved = state.begin_save().expect("save should start");
+
+        let _task = reduce(&mut state, SettingsIntent::Save);
+
+        assert!(state.begin_save().is_none());
     }
 
     #[test]
     fn given_save_failed_when_reduced_then_keeps_state_dirty() {
         let mut state = default_state();
         state.set_editor(String::from("vim"));
+        let _settings = state.begin_save().expect("save should start");
         assert!(state.is_dirty());
 
         let _task = reduce(
@@ -149,7 +215,9 @@ mod tests {
         );
 
         assert!(state.is_dirty());
+        assert!(!state.is_saving());
         assert_ne!(state.baseline(), state.draft());
+        assert!(state.begin_save().is_some());
     }
 
     #[test]

--- a/app/src/widgets/settings/state.rs
+++ b/app/src/widgets/settings/state.rs
@@ -15,6 +15,7 @@ pub(crate) struct SettingsState {
     selected_path: Vec<String>,
     hovered_path: Option<Vec<String>>,
     dirty: bool,
+    saving: bool,
 }
 
 impl SettingsState {
@@ -64,6 +65,11 @@ impl SettingsState {
         self.dirty
     }
 
+    /// Return whether a save is currently being written to disk.
+    pub(crate) fn is_saving(&self) -> bool {
+        self.saving
+    }
+
     /// Create state from a persisted settings payload.
     pub(crate) fn from_settings(settings: SettingsData) -> Self {
         let tree = vec![
@@ -85,6 +91,7 @@ impl SettingsState {
             selected_path,
             hovered_path: None,
             dirty: false,
+            saving: false,
         }
     }
 
@@ -104,9 +111,25 @@ impl SettingsState {
         self.draft.normalized()
     }
 
+    /// Capture the current draft for one save, locking out further edits.
+    pub(super) fn begin_save(&mut self) -> Option<SettingsData> {
+        if self.saving || !self.dirty {
+            return None;
+        }
+
+        self.saving = true;
+        Some(self.normalized_draft())
+    }
+
     /// Mark the draft as saved by replacing baseline with the given data.
     pub(super) fn mark_saved(&mut self, settings: SettingsData) {
+        self.saving = false;
         self.replace_with_settings(settings);
+    }
+
+    /// Unlock editing so a failed save can be retried.
+    pub(super) fn mark_save_failed(&mut self) {
+        self.saving = false;
     }
 
     /// Reset draft to baseline.
@@ -246,6 +269,17 @@ mod tests {
 
         assert_eq!(state.draft, baseline);
         assert!(!state.dirty);
+    }
+
+    #[test]
+    fn given_save_in_flight_when_begin_save_called_again_then_second_is_ignored()
+     {
+        let mut state = SettingsState::default();
+        state.set_editor(String::from("vim"));
+
+        assert!(state.begin_save().is_some());
+
+        assert!(state.begin_save().is_none());
     }
 
     #[test]

--- a/app/src/widgets/settings/view/settings_form.rs
+++ b/app/src/widgets/settings/view/settings_form.rs
@@ -70,18 +70,12 @@ pub(crate) fn view(
 fn settings_header<'a>(
     props: &SettingsFormProps<'a>,
 ) -> Element<'a, SettingsIntent, Theme, iced::Renderer> {
-    let save_button = action_button(
-        "Save",
-        props.vm.is_dirty,
-        SettingsIntent::Save,
-        props.theme,
-    );
-    let reset_button = action_button(
-        "Reset",
-        props.vm.is_dirty,
-        SettingsIntent::Reset,
-        props.theme,
-    );
+    let is_enabled = props.vm.is_dirty && !props.vm.is_saving;
+
+    let save_button =
+        action_button("Save", is_enabled, SettingsIntent::Save, props.theme);
+    let reset_button =
+        action_button("Reset", is_enabled, SettingsIntent::Reset, props.theme);
 
     let actions =
         row![save_button, reset_button].spacing(HEADER_BUTTON_SPACING);
@@ -212,26 +206,35 @@ fn settings_form<'a>(
 fn terminal_form<'a>(
     props: &SettingsFormProps<'a>,
 ) -> Element<'a, SettingsIntent, Theme, iced::Renderer> {
-    let shell_input = text_input("", props.vm.draft.terminal_shell())
-        .on_input(SettingsIntent::ShellChanged)
+    let is_editable = !props.vm.is_saving;
+
+    let mut shell_input = text_input("", props.vm.draft.terminal_shell())
         .padding([FORM_INPUT_PADDING_Y, FORM_INPUT_PADDING_X])
         .size(FORM_INPUT_FONT_SIZE)
         .width(Length::Fill)
         .style(text_input_style(props.theme));
+    if is_editable {
+        shell_input = shell_input.on_input(SettingsIntent::ShellChanged);
+    }
 
-    let editor_input = text_input("", props.vm.draft.terminal_editor())
-        .on_input(SettingsIntent::EditorChanged)
+    let mut editor_input = text_input("", props.vm.draft.terminal_editor())
         .padding([FORM_INPUT_PADDING_Y, FORM_INPUT_PADDING_X])
         .size(FORM_INPUT_FONT_SIZE)
         .width(Length::Fill)
         .style(text_input_style(props.theme));
+    if is_editable {
+        editor_input = editor_input.on_input(SettingsIntent::EditorChanged);
+    }
 
-    let equalize_panes_toggle = checkbox(props.vm.draft.equalize_panes())
+    let mut equalize_panes_toggle = checkbox(props.vm.draft.equalize_panes())
         .label("Even out sibling pane widths on split and close")
-        .on_toggle(SettingsIntent::EqualizePanesToggled)
         .size(FORM_INPUT_FONT_SIZE)
         .text_size(FORM_INPUT_FONT_SIZE)
         .style(checkbox_style(props.theme));
+    if is_editable {
+        equalize_panes_toggle = equalize_panes_toggle
+            .on_toggle(SettingsIntent::EqualizePanesToggled);
+    }
 
     let content = column![
         section_title("Terminal", props.theme),
@@ -248,6 +251,8 @@ fn terminal_form<'a>(
 fn theme_form<'a>(
     props: &SettingsFormProps<'a>,
 ) -> Element<'a, SettingsIntent, Theme, iced::Renderer> {
+    let is_editable = !props.vm.is_saving;
+
     let preset_selector = pick_list(
         SettingsPreset::ALL,
         props.vm.selected_preset,
@@ -276,15 +281,16 @@ fn theme_form<'a>(
             .align_x(alignment::Horizontal::Left)
             .wrapping(Wrapping::None);
 
-        let input = text_input("", value)
-            .on_input(move |value| SettingsIntent::PaletteChanged {
-                index,
-                value,
-            })
+        let mut input = text_input("", value)
             .padding([FORM_INPUT_PADDING_Y, FORM_INPUT_PADDING_X])
             .size(FORM_INPUT_FONT_SIZE)
             .width(Length::Fill)
             .style(text_input_style(props.theme));
+        if is_editable {
+            input = input.on_input(move |value| {
+                SettingsIntent::PaletteChanged { index, value }
+            });
+        }
 
         let swatch_color = if is_valid_hex_color(value) {
             parse_hex_color(value)


### PR DESCRIPTION
## Summary

- block draft edits while a settings save is in flight, so a save completion cannot overwrite a newer edit
- keep Save and Reset disabled for the duration of the write
- unlock editing on completion or failure, so a failed save can be retried

## Root cause

A save completion replaced the entire settings state with the snapshot written to disk. If the user edited another field before the asynchronous save completed, that newer draft was silently overwritten.

## Approach

The state keeps one `saving` flag. While it is set, the reducer ignores every intent that changes the draft (`Reset`, `ShellChanged`, `EditorChanged`, `EqualizePanesToggled`, `PaletteChanged`, `ApplyPreset`), the form inputs drop their `on_input` / `on_toggle` handlers, and Save and Reset are disabled. `SaveCompleted` and `SaveFailed` both clear the flag.

`SettingsIntent::Save` has exactly one trigger — the Save button in `settings_header` — and the write touches one local file, so the lock window is a few milliseconds.

The theme preset `pick_list` cannot drop its handler the way `text_input` and `checkbox` can, so the reducer guard is what actually blocks it; the disabled inputs are the visible half of the same rule.

## Verification

- `cargo test --workspace --all-features`: all green
- settings tests: 31 passed
- red-green: with the reducer guard removed, `given_save_in_flight_when_edit_intent_reduced_then_draft_unchanged` and `given_save_in_flight_when_reset_intent_reduced_then_draft_unchanged` both fail; restored, both pass
- `cargo +nightly fmt`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo deny check`: advisories ok, bans ok, licenses ok, sources ok

## Notes

`cargo deny` reports the existing yanked transitive dependencies `core2 0.4.0` and `spin 0.9.8`.

`otty-ui-term`'s `double_click_clears_selection` is a pre-existing timing flake: it fails roughly one run in five on an unmodified checkout and lives in a crate this change does not touch.
