### PR TITLE
fix(pty): re-arm SSH readiness after WouldBlock

### DIFF
--- a/crates/pty/src/ssh.rs
+++ b/crates/pty/src/ssh.rs
@@ -104,6 +104,13 @@ impl SSHSession {
             Err(err) => Err(SessionError::SSH2(err)),
         }
     }
+
+    /// Handle channel EOF: cache the exit status and notify the poller.
+    fn finish_eof(&mut self) -> Result<usize, SessionError> {
+        let _ = self.try_get_exit_status();
+        self.notify_exit()?;
+        Ok(0)
+    }
 }
 
 impl Session for SSHSession {
@@ -112,13 +119,23 @@ impl Session for SSHSession {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, SessionError> {
         match self.channel.read(buf) {
             // Channel receive the EOF so we need to notify of exit
-            Ok(0) => {
-                let _ = self.try_get_exit_status();
-                self.notify_exit()?;
-                Ok(0)
-            },
+            Ok(0) => self.finish_eof(),
             Ok(n) => Ok(n),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                rearm_readiness(&self.io)?;
+
+                // Data may arrive between the libssh2 call and the re-arm
+                // peek; retry once so the engine does not stall waiting for
+                // a readiness event that will not be delivered.
+                match self.channel.read(buf) {
+                    Ok(0) => self.finish_eof(),
+                    Ok(n) => Ok(n),
+                    Err(retry) if retry.kind() == io::ErrorKind::WouldBlock => {
+                        Ok(0)
+                    },
+                    Err(retry) => Err(SessionError::IO(retry)),
+                }
+            },
             Err(e) => Err(SessionError::IO(e)),
         }
     }
@@ -131,7 +148,20 @@ impl Session for SSHSession {
                 let _ = self.channel.flush();
                 Ok(n)
             },
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                rearm_readiness(&self.io)?;
+
+                match self.channel.write(input) {
+                    Ok(n) => {
+                        let _ = self.channel.flush();
+                        Ok(n)
+                    },
+                    Err(retry) if retry.kind() == io::ErrorKind::WouldBlock => {
+                        Ok(0)
+                    },
+                    Err(retry) => Err(SessionError::IO(retry)),
+                }
+            },
             Err(e) => Err(SessionError::IO(e)),
         }
     }
@@ -547,4 +577,86 @@ fn exit_status_from_code(code: i32) -> ExitStatus {
 #[cfg(windows)]
 fn exit_status_from_code(code: i32) -> ExitStatus {
     std::os::windows::process::ExitStatusExt::from_raw(code as u32)
+}
+
+/// Re-arm mio's edge-triggered readiness after a raw-socket WouldBlock.
+///
+/// All channel I/O bypasses mio because libssh2 owns the socket, so mio's
+/// Windows backend never observes the WouldBlock it uses as the signal to
+/// re-register interest. Peeking one byte through the mio socket hits
+/// WouldBlock once the kernel buffer is drained, which triggers mio's internal
+/// re-registration without consuming any data.
+#[cfg(windows)]
+fn rearm_readiness(io: &mio::net::TcpStream) -> Result<(), SessionError> {
+    match io.peek(&mut [0u8; 1]) {
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(()),
+        Err(err) => Err(SessionError::IO(err)),
+    }
+}
+
+/// No-op on unix: mio is level-triggered there and needs no re-arming.
+#[cfg(not(windows))]
+fn rearm_readiness(_io: &mio::net::TcpStream) -> Result<(), SessionError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    use super::rearm_readiness;
+
+    fn loopback_pair() -> (mio::net::TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let client = TcpStream::connect(addr).expect("connect");
+        let (server, _) = listener.accept().expect("accept");
+        client.set_nonblocking(true).expect("set nonblocking");
+
+        (mio::net::TcpStream::from_std(client), server)
+    }
+
+    fn wait_until_readable(client: &mut mio::net::TcpStream) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match client.peek(&mut [0u8; 1]) {
+                Ok(_) => return,
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "socket did not become readable before timeout"
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                },
+                Err(err) => panic!("peek failed while waiting: {err}"),
+            }
+        }
+    }
+
+    #[test]
+    fn rearm_on_empty_socket_is_ok_and_nonblocking() {
+        let (client, _server) = loopback_pair();
+
+        let result = rearm_readiness(&client);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rearm_does_not_consume_pending_data() {
+        let (mut client, mut server) = loopback_pair();
+        server.write_all(b"x").expect("write payload");
+        wait_until_readable(&mut client);
+
+        let result = rearm_readiness(&client);
+
+        assert!(result.is_ok());
+        let mut buf = [0u8; 1];
+        let read = client.read(&mut buf).expect("read after rearm");
+        assert_eq!(&buf[..read], b"x", "rearm must not consume data");
+    }
 }

--- a/crates/pty/src/ssh.rs
+++ b/crates/pty/src/ssh.rs
@@ -117,25 +117,11 @@ impl Session for SSHSession {
     /// Read from the SSH channel in non-blocking mode, emitting the bytes that
     /// arrive from the remote PTY.
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, SessionError> {
-        match self.channel.read(buf) {
+        match self.io.try_io(|| self.channel.read(buf)) {
             // Channel receive the EOF so we need to notify of exit
             Ok(0) => self.finish_eof(),
             Ok(n) => Ok(n),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                rearm_readiness(&self.io)?;
-
-                // Data may arrive between the libssh2 call and the re-arm
-                // peek; retry once so the engine does not stall waiting for
-                // a readiness event that will not be delivered.
-                match self.channel.read(buf) {
-                    Ok(0) => self.finish_eof(),
-                    Ok(n) => Ok(n),
-                    Err(retry) if retry.kind() == io::ErrorKind::WouldBlock => {
-                        Ok(0)
-                    },
-                    Err(retry) => Err(SessionError::IO(retry)),
-                }
-            },
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
             Err(e) => Err(SessionError::IO(e)),
         }
     }
@@ -143,25 +129,12 @@ impl Session for SSHSession {
     /// Forward bytes to the remote PTY, respecting libssh2's non-blocking
     /// semantics.
     fn write(&mut self, input: &[u8]) -> Result<usize, SessionError> {
-        match self.channel.write(input) {
+        match self.io.try_io(|| self.channel.write(input)) {
             Ok(n) => {
                 let _ = self.channel.flush();
                 Ok(n)
             },
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                rearm_readiness(&self.io)?;
-
-                match self.channel.write(input) {
-                    Ok(n) => {
-                        let _ = self.channel.flush();
-                        Ok(n)
-                    },
-                    Err(retry) if retry.kind() == io::ErrorKind::WouldBlock => {
-                        Ok(0)
-                    },
-                    Err(retry) => Err(SessionError::IO(retry)),
-                }
-            },
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
             Err(e) => Err(SessionError::IO(e)),
         }
     }
@@ -579,36 +552,12 @@ fn exit_status_from_code(code: i32) -> ExitStatus {
     std::os::windows::process::ExitStatusExt::from_raw(code as u32)
 }
 
-/// Re-arm mio's edge-triggered readiness after a raw-socket WouldBlock.
-///
-/// All channel I/O bypasses mio because libssh2 owns the socket, so mio's
-/// Windows backend never observes the WouldBlock it uses as the signal to
-/// re-register interest. Peeking one byte through the mio socket hits
-/// WouldBlock once the kernel buffer is drained, which triggers mio's internal
-/// re-registration without consuming any data.
-#[cfg(windows)]
-fn rearm_readiness(io: &mio::net::TcpStream) -> Result<(), SessionError> {
-    match io.peek(&mut [0u8; 1]) {
-        Ok(_) => Ok(()),
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(()),
-        Err(err) => Err(SessionError::IO(err)),
-    }
-}
-
-/// No-op on unix: mio is level-triggered there and needs no re-arming.
-#[cfg(not(windows))]
-fn rearm_readiness(_io: &mio::net::TcpStream) -> Result<(), SessionError> {
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::thread;
     use std::time::{Duration, Instant};
-
-    use super::rearm_readiness;
 
     fn loopback_pair() -> (mio::net::TcpStream, TcpStream) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -638,23 +587,28 @@ mod tests {
     }
 
     #[test]
-    fn rearm_on_empty_socket_is_ok_and_nonblocking() {
+    fn try_io_on_empty_socket_is_nonblocking() {
         let (client, _server) = loopback_pair();
 
-        let result = rearm_readiness(&client);
+        let result = client.try_io(|| client.peek(&mut [0u8; 1]));
 
-        assert!(result.is_ok());
+        assert_eq!(
+            result
+                .expect_err("empty socket should not be readable")
+                .kind(),
+            std::io::ErrorKind::WouldBlock,
+        );
     }
 
     #[test]
-    fn rearm_does_not_consume_pending_data() {
+    fn try_io_does_not_consume_pending_data() {
         let (mut client, mut server) = loopback_pair();
         server.write_all(b"x").expect("write payload");
         wait_until_readable(&mut client);
 
-        let result = rearm_readiness(&client);
+        let result = client.try_io(|| client.peek(&mut [0u8; 1]));
 
-        assert!(result.is_ok());
+        assert_eq!(result.expect("readable socket should be peekable"), 1);
         let mut buf = [0u8; 1];
         let read = client.read(&mut buf).expect("read after rearm");
         assert_eq!(&buf[..read], b"x", "rearm must not consume data");


### PR DESCRIPTION
## Summary

This is a replacement PR for #79 because the original contributor fork branch is not writable from my account.

It reapplies the Windows SSH readiness fix onto the current repository layout after the crate reorganization moved `otty-pty/src/ssh.rs` to `crates/pty/src/ssh.rs`.

## What changed

- Routes libssh2 channel reads and writes through `mio::net::TcpStream::try_io`.
- Lets mio observe `WouldBlock` and update its platform-specific readiness bookkeeping, including the Windows backend.
- Preserves the existing non-blocking `WouldBlock` behavior without manually peeking, re-arming, or retrying channel I/O.
- Adds loopback socket regression tests proving `try_io` is non-blocking on an empty socket and does not consume pending data.

## Verification

- `cargo +nightly fmt -- --check`: passed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed with the existing `block v0.1.6` future-incompatibility warning.
- `cargo deny check`: passed with existing yanked warnings for `core2 0.4.0` and `spin 0.9.8`.
- `cargo test --workspace --all-features`: passed, 532 passed / 2 ignored.
- `cargo llvm-cov --workspace --all-features --fail-under-lines 80`: failed the existing repository-wide threshold with 68.76% line coverage.

## Not verified

- Windows runtime behavior on a real SSH session. The current host is macOS; the change is covered by unit-level loopback socket tests.
